### PR TITLE
readme.md with a used-by u8-mqtt package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,7 @@ Your RegExp pattern.
 
 - [trouter](https://github.com/lukeed/trouter) - A server-side HTTP router that extends from this module.
 - [matchit](https://github.com/lukeed/matchit) - Similar (650B) library, but relies on String comparison instead of `RegExp`s.
+- [u8-mqtt](https://github.com/shanewholloway/js-u8-mqtt) - An MQTT client that embeds `regexparam` for routing published packets by topic.
 
 
 ## License


### PR DESCRIPTION
@lukeed, thank you for creating `regexparam` (and `polka`). It was a joy to build on your lean-and-mean route matching utility for `u8-mqtt`.

Cheers,
-Shane