### PR TITLE
fix(types): exclude file extension from inferred param name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,10 +11,14 @@ export function parse(route: RegExp): {
 export type RouteParams<T extends string> =
 	T extends `${infer Prev}/*/${infer Rest}`
 		? RouteParams<Prev> & { wild: string } & RouteParams<Rest>
+	: T extends `${string}:${infer P}.${string}/${infer Rest}`
+		? { [K in P]: string } & RouteParams<Rest>
 	: T extends `${string}:${infer P}?/${infer Rest}`
 		? { [K in P]?: string } & RouteParams<Rest>
 	: T extends `${string}:${infer P}/${infer Rest}`
 		? { [K in P]: string } & RouteParams<Rest>
+	: T extends `${string}:${infer P}.${string}`
+		? { [K in P]: string }
 	: T extends `${string}:${infer P}?`
 		? { [K in P]?: string }
 	: T extends `${string}:${infer P}`

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,8 @@ export type RouteParams<T extends string> =
 		? { [K in P]?: string }
 	: T extends `${string}:${infer P}`
 		? { [K in P]: string }
+	: T extends `${string}*.${string}`
+		? { wild: string }
 	: T extends `${string}*`
 		? { wild: string }
 	: {};


### PR DESCRIPTION
Previously, the `RouteParams` type would include the file extension in the parameter name.

```ts
type Example = RouteParams<"/:name.webp">
// Before: { "name.webp": string }
// After:  { name: string }
```