### PR TITLE
package.json: add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./index.d.ts"
+      "require": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
`exports` requires `types` to be specified (it won't fallback to the top-level `types`).