### PR TITLE
Add implementation signature of parse function to fix typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,11 @@ export function parse(route: RegExp): {
 	pattern: RegExp;
 }
 
+export function parse(route: string | RegExp, loose?: boolean): {
+	keys: string[] | false;
+	pattern: RegExp;
+}
+
 export type RouteParams<T extends string> =
 	T extends `${infer Prev}/*/${infer Rest}`
 		? RouteParams<Prev> & { wild: string } & RouteParams<Rest>


### PR DESCRIPTION
Without implementation signature we get an error when passing `string | RegExp` to the `parse` function:
```ts
declare const route: string | RegExp;
parse(route);
/*
No overload matches this call.
  Overload 1 of 2, '(route: string, loose?: boolean | undefined): { keys: string[]; pattern: RegExp; }', gave the following error.
    Argument of type 'string | RegExp' is not assignable to parameter of type 'string'.
      Type 'RegExp' is not assignable to type 'string'.
  Overload 2 of 2, '(route: RegExp): { keys: false; pattern: RegExp; }', gave the following error.
    Argument of type 'string | RegExp' is not assignable to parameter of type 'RegExp'.
      Type 'string' is not assignable to type 'RegExp'.(2769)
*/
```
https://www.typescriptlang.org/play/?#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwAdYBnEAChh2QxAC55iMYtUBzAGnghx1IH56AIx4QQUVAEp6AbwBQASADWIAJ7F6jZmwDaAXQDcCohhoxU9AEohWAUQAeBQwF9Zs0JFgIU6bHkIlySmo6eCtbByl4OSVVdSQoCFJDeWNTc1Dre0dZF1d3aDh4MDxGeCCaDSYWVngAHwzw7NkiGFIKKhoJQyA

To fix this, I add the implementation signature to the `parse` function: https://www.typescriptlang.org/play/?ssl=17&ssc=14&pln=15&pc=1#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwAdYBnEAChh2QxAC55iMYtUBzAGnghx1IH56AIx4QQUVAEp6AbwBQASADWIAJ7F6jZmwDaAXQDcCohhoxU9AEohWAUQAeBQwF9ZoSLAQp02PIRLlKajp4K1sHKXg5JVV1JCgIUkN5Y1NzEOt7R1kXN2g4JDRMXHwiGFIKKhoNJhZWeAAfdLCCTm5eEAF4YRxRcQio5TVqrVY9BriEkCSUkDNLDIdnWWXcj3gwPEZ4QKqGGrZx0MzDWVLynZAJfSA