### PR TITLE
fix: strict type definitions for RouteParams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,21 +8,26 @@ export function parse(route: RegExp): {
 	pattern: RegExp;
 }
 
+type KeyRecord<T extends string> =
+	T extends `${infer P}?` // :id?
+		? { [K in P]?: string | undefined }
+	: T extends `${infer P}.${string}` // :id.ext
+		? { [K in P]: string }
+	: { [K in T]: string };
+
 export type RouteParams<T extends string> =
 	T extends `${infer Prev}/*/${infer Rest}`
-		? RouteParams<Prev> & { wild: string } & RouteParams<Rest>
-	: T extends `${string}:${infer P}?/${infer Rest}`
-		? { [K in P]?: string } & RouteParams<Rest>
-	: T extends `${string}:${infer P}/${infer Rest}`
-		? { [K in P]: string } & RouteParams<Rest>
-	: T extends `${string}:${infer P}?`
-		? { [K in P]?: string }
-	: T extends `${string}:${infer P}`
-		? { [K in P]: string }
-	: T extends `${string}*`
+		? RouteParams<Prev> & { wild: string } & RouteParams<`/${Rest}`>
+	: T extends `:${infer Rest}`
+		? RouteParams<`/:${Rest}`>
+	: T extends `${string}/:${infer P}/${infer Rest}`
+		? KeyRecord<P> & RouteParams<`/${Rest}`>
+	: T extends `${string}/:${infer P}`
+		? KeyRecord<P>
+	: T extends `${string}/*`
 		? { "*": string }
-	: T extends `${string}*?`
-		? { "*"?: string }
+	: T extends `${string}/*?`
+		? { "*"?: string | undefined }
 	: {};
 
 export function inject<T extends string>(route: T, values: RouteParams<T>): string;


### PR DESCRIPTION
Fixed a problem that RouteParams type was not correctly inferred in cases where an extension was given, such as `/foo/:bar.mp4`.

Also, fixed the problem that `:action` part was mis-detected when paths like `/foo/bar:action` were defined in Custom methods of Google API Improvement Proposals.